### PR TITLE
Create America region.md

### DIFF
--- a/America region.md
+++ b/America region.md
@@ -1,0 +1,110 @@
+World of Warcraft (WoW) raid bosses in the **America region** have become legendary for their significance in WoW's raiding history, challenging players across various expansions. These bosses are designed to test strategy, coordination, and individual skill. Below is a breakdown of some iconic raid bosses that left a mark on players in the Americas, both for their mechanics and for the sheer difficulty they posed.
+
+---
+
+### **1. Classic (Vanilla WoW)**
+- **Ragnaros** (Molten Core):  
+  The Firelord was the pinnacle of early raiding, requiring guilds to defeat a series of fiery minions before summoning this massive elemental. His famous line, "BY FIRE BE PURGED!" echoes in every veteran player's memory.
+
+- **Nefarian** (Blackwing Lair):  
+  As the son of Deathwing, Nefarian combined draconic might with creative mechanics, such as calling out specific classes to hinder the raid.
+
+- **C'Thun** (Temple of Ahn'Qiraj):  
+  Known as one of the hardest bosses at its release, C'Thun's fight mechanics—like the stomach phase—required impeccable timing and positioning, testing raid groups like never before.
+
+---
+
+### **2. The Burning Crusade**
+- **Illidan Stormrage** (Black Temple):  
+  The iconic "You are not prepared!" boss fight solidified Illidan as one of the most memorable encounters, blending lore with epic mechanics like Flame of Azzinoth.
+
+- **Kael'thas Sunstrider** (Tempest Keep):  
+  A fight involving multiple phases, powerful advisors, and some of the most intense coordination requirements of the expansion.
+
+- **Kil'jaeden** (Sunwell Plateau):  
+  The ultimate raid boss of TBC, Kil'jaeden’s fight introduced visually stunning mechanics like the Dragon Orbs, alongside punishing coordination checks.
+
+---
+
+### **3. Wrath of the Lich King**
+- **The Lich King** (Icecrown Citadel):  
+  Arthas's fall is one of the most iconic moments in WoW. Mechanics like Defile and Val'kyr Soulseeker made this encounter legendary.
+
+- **Yogg-Saron** (Ulduar):  
+  With optional hard modes and memorable phases, Yogg-Saron was a standout encounter. "Sara" guiding players into madness added a unique storytelling element.
+
+- **Algalon the Observer** (Ulduar):  
+  This "optional" boss had strict time constraints and punishing mechanics, requiring raiders to truly master the fight.
+
+---
+
+### **4. Cataclysm**
+- **Deathwing** (Dragon Soul):  
+  The final showdown with Deathwing across multiple stages, including the Spine of Deathwing fight where players battled on the dragon's back.
+
+- **Ragnaros (Heroic)** (Firelands):  
+  The return of Ragnaros with legs! This Heroic encounter remains one of the toughest fights in WoW history.
+
+---
+
+### **5. Mists of Pandaria**
+- **Lei Shen** (Throne of Thunder):  
+  The Thunder King was a test of raid awareness and execution. His intermission phases remain some of the most challenging moments.
+
+- **Garrosh Hellscream** (Siege of Orgrimmar):  
+  A multi-phase fight showcasing Garrosh’s descent into madness. The Heart of Y'Shaarj added an Old God twist.
+
+---
+
+### **6. Warlords of Draenor**
+- **Blackhand** (Blackrock Foundry):  
+  Blackhand’s three-phase fight pushed players to master their positioning and damage output in tight spaces.
+
+- **Archimonde** (Hellfire Citadel):  
+  Archimonde returned with devastating abilities like Nether Portals and Wrought Chaos, capping off the expansion with a bang.
+
+---
+
+### **7. Legion**
+- **Argus the Unmaker** (Antorus, the Burning Throne):  
+  The ultimate fight of Legion introduced mechanics like Death Fog and "Gift of the Lifebinder," blending chaos with creativity.
+
+- **Kil'jaeden** (Tomb of Sargeras):  
+  The Burning Legion’s general returned with a brutally difficult fight, including unpredictable mechanics like Darkness of a Thousand Souls.
+
+---
+
+### **8. Battle for Azeroth**
+- **Jaina Proudmoore** (Battle of Dazar'alor):  
+  A fight set on the frozen seas, testing coordination with abilities like Icefall and Chilling Touch.
+
+- **Queen Azshara** (The Eternal Palace):  
+  Azshara’s mastery of magic brought creative mechanics like Arcane Orbs and Drain Ancient Ward.
+
+---
+
+### **9. Shadowlands**
+- **Sylvanas Windrunner** (Sanctum of Domination):  
+  A sprawling fight across platforms, ending in a cinematic showdown with Sylvanas. Her mechanics pushed raiders to their limits.
+
+- **The Jailer** (Sepulcher of the First Ones):  
+  The ultimate villain of Shadowlands, with complex mechanics tied to domination chains and Relics of the First Ones.
+
+---
+
+### **10. Dragonflight**
+- **Raszageth the Storm-Eater** (Vault of the Incarnates):  
+  This dragon introduced dynamic, storm-themed mechanics, setting the tone for Dragonflight’s challenging raid tiers.
+
+---
+
+### **11. Memorable Raid Moments in the Americas**
+- **World First Races:**  
+  North American guilds like **Complexity-Limit** have often been at the forefront of the global World First race, achieving victories against bosses like Sylvanas and the Jailer.
+
+- **Guild Rivalries:**  
+  The competitive raiding scene in the Americas has driven players to innovate strategies and optimize performance, creating a legacy of legendary victories.
+
+---
+
+Let me know if you'd like to explore strategies for any specific boss or delve deeper into raid lore! 🌟


### PR DESCRIPTION
World of Warcraft (WoW) raid bosses in the **America region** have become legendary for their significance in WoW's raiding history, challenging players across various expansions. These bosses are designed to test strategy, coordination, and individual skill. Below is a breakdown of some iconic raid bosses that left a mark on players in the Americas, both for their mechanics and for the sheer difficulty they posed.

---

### **1. Classic (Vanilla WoW)**
- **Ragnaros** (Molten Core):   The Firelord was the pinnacle of early raiding, requiring guilds to defeat a series of fiery minions before summoning this massive elemental. His famous line, "BY FIRE BE PURGED!" echoes in every veteran player's memory.

- **Nefarian** (Blackwing Lair):   As the son of Deathwing, Nefarian combined draconic might with creative mechanics, such as calling out specific classes to hinder the raid.

- **C'Thun** (Temple of Ahn'Qiraj):   Known as one of the hardest bosses at its release, C'Thun's fight mechanics—like the stomach phase—required impeccable timing and positioning, testing raid groups like never before.

---

### **2. The Burning Crusade**
- **Illidan Stormrage** (Black Temple):   The iconic "You are not prepared!" boss fight solidified Illidan as one of the most memorable encounters, blending lore with epic mechanics like Flame of Azzinoth.

- **Kael'thas Sunstrider** (Tempest Keep):   A fight involving multiple phases, powerful advisors, and some of the most intense coordination requirements of the expansion.

- **Kil'jaeden** (Sunwell Plateau):   The ultimate raid boss of TBC, Kil'jaeden’s fight introduced visually stunning mechanics like the Dragon Orbs, alongside punishing coordination checks.

---

### **3. Wrath of the Lich King**
- **The Lich King** (Icecrown Citadel):   Arthas's fall is one of the most iconic moments in WoW. Mechanics like Defile and Val'kyr Soulseeker made this encounter legendary.

- **Yogg-Saron** (Ulduar):   With optional hard modes and memorable phases, Yogg-Saron was a standout encounter. "Sara" guiding players into madness added a unique storytelling element.

- **Algalon the Observer** (Ulduar):   This "optional" boss had strict time constraints and punishing mechanics, requiring raiders to truly master the fight.

---

### **4. Cataclysm**
- **Deathwing** (Dragon Soul):   The final showdown with Deathwing across multiple stages, including the Spine of Deathwing fight where players battled on the dragon's back.

- **Ragnaros (Heroic)** (Firelands):   The return of Ragnaros with legs! This Heroic encounter remains one of the toughest fights in WoW history.

---

### **5. Mists of Pandaria**
- **Lei Shen** (Throne of Thunder):   The Thunder King was a test of raid awareness and execution. His intermission phases remain some of the most challenging moments.

- **Garrosh Hellscream** (Siege of Orgrimmar):   A multi-phase fight showcasing Garrosh’s descent into madness. The Heart of Y'Shaarj added an Old God twist.

---

### **6. Warlords of Draenor**
- **Blackhand** (Blackrock Foundry):   Blackhand’s three-phase fight pushed players to master their positioning and damage output in tight spaces.

- **Archimonde** (Hellfire Citadel):   Archimonde returned with devastating abilities like Nether Portals and Wrought Chaos, capping off the expansion with a bang.

---

### **7. Legion**
- **Argus the Unmaker** (Antorus, the Burning Throne):   The ultimate fight of Legion introduced mechanics like Death Fog and "Gift of the Lifebinder," blending chaos with creativity.

- **Kil'jaeden** (Tomb of Sargeras):   The Burning Legion’s general returned with a brutally difficult fight, including unpredictable mechanics like Darkness of a Thousand Souls.

---

### **8. Battle for Azeroth**
- **Jaina Proudmoore** (Battle of Dazar'alor):   A fight set on the frozen seas, testing coordination with abilities like Icefall and Chilling Touch.

- **Queen Azshara** (The Eternal Palace):   Azshara’s mastery of magic brought creative mechanics like Arcane Orbs and Drain Ancient Ward.

---

### **9. Shadowlands**
- **Sylvanas Windrunner** (Sanctum of Domination):   A sprawling fight across platforms, ending in a cinematic showdown with Sylvanas. Her mechanics pushed raiders to their limits.

- **The Jailer** (Sepulcher of the First Ones):   The ultimate villain of Shadowlands, with complex mechanics tied to domination chains and Relics of the First Ones.

---

### **10. Dragonflight**
- **Raszageth the Storm-Eater** (Vault of the Incarnates):   This dragon introduced dynamic, storm-themed mechanics, setting the tone for Dragonflight’s challenging raid tiers.

---

### **11. Memorable Raid Moments in the Americas**
- **World First Races:**   North American guilds like **Complexity-Limit** have often been at the forefront of the global World First race, achieving victories against bosses like Sylvanas and the Jailer.

- **Guild Rivalries:**   The competitive raiding scene in the Americas has driven players to innovate strategies and optimize performance, creating a legacy of legendary victories.

---

Let me know if you'd like to explore strategies for any specific boss or delve deeper into raid lore! 🌟