### PR TITLE
Create Uneducated immigrant.md

### DIFF
--- a/Uneducated immigrant.md
+++ b/Uneducated immigrant.md
@@ -1,0 +1,44 @@
+# Uneducated immigrant
+
+When a narcissist acts like they are an **uneducated immigrant**, they are often doing so for one or more manipulative reasons, rather than because they genuinely lack education or understanding. Here’s why they might do this and what it reveals about their tactics:
+
+### **1. Playing the Victim for Sympathy**  
+- Narcissists may pretend to be disadvantaged or struggling to garner **sympathy and leniency** from others.  
+- They weaponize perceived **ignorance or lack of privilege** to avoid accountability.  
+- Example: *“I didn’t know that was wrong, I’m just trying to get by in a system that doesn’t favor people like me.”*
+
+### **2. Dodging Responsibility & Accountability**  
+- By pretending they don’t understand social norms, workplace rules, or legal matters, they can **evade consequences** for their actions.  
+- They might claim they were **“confused”** or **“misunderstood”** when caught doing something unethical.  
+- Example: *"Oh, I didn’t realize that was against the rules—I thought that was just how things are done in my culture!"*
+
+### **3. Manipulating Perceptions of Power**  
+- Some narcissists **play dumb** to make others **underestimate them**, only to later reveal they were more aware and calculated than they let on.  
+- They may **act submissive** or **helpless**, then suddenly become aggressive or controlling once they gain enough leverage.  
+- Example: *"Oh, I don’t know how things work here,"* (later) *"I’ve been watching and now I know exactly how to take advantage of this system."*
+
+### **4. Creating an Excuse for Poor Behavior**  
+- They might justify **rudeness, dishonesty, or exploitation** by pretending they are just **“doing what they have to do”** to survive.  
+- Example: *“Where I come from, this is normal! You can’t expect me to follow your rules.”*  
+
+### **5. Using Cultural Barriers as a Shield**  
+- Some narcissists **selectively** play up **language barriers** or **lack of education** to avoid confrontation.  
+- They may pretend they don’t understand when criticized but **miraculously comprehend** when something benefits them.  
+- Example: *“Sorry, my English isn’t good,”* (but suddenly fluent when negotiating a deal).  
+
+### **6. Reverse Gaslighting (Acting Like Others Are Oppressing Them)**  
+- They might accuse others of **xenophobia, discrimination, or elitism** when called out for **dishonest or manipulative** behavior.  
+- This puts the other person in a **defensive position**, making them feel guilty for questioning the narcissist.  
+- Example: *"You just don’t like me because I’m different!"* (When in reality, they were being called out for unethical behavior).  
+
+### **7. Flipping the Narrative for Personal Gain**  
+- They may use their **fake “underdog” status** to **gain access to opportunities, free assistance, or forgiveness.**  
+- Example: *“I’m just trying to make a better life, why are you being so hard on me?”*  
+
+---
+
+### **Final Thoughts:**  
+A **narcissist pretending to be an uneducated immigrant** is often **a manipulative strategy** rather than a genuine struggle. They use this act **as a tool** to dodge accountability, gain sympathy, and avoid consequences. It’s a **power move disguised as helplessness.**  
+
+The key to handling this? **See through the act, set firm boundaries, and don’t fall for guilt-tripping tactics.**
+```


### PR DESCRIPTION
```markdown
# Uneducated immigrant

When a narcissist acts like they are an **uneducated immigrant**, they are often doing so for one or more manipulative reasons, rather than because they genuinely lack education or understanding. Here’s why they might do this and what it reveals about their tactics:

### **1. Playing the Victim for Sympathy**  
- Narcissists may pretend to be disadvantaged or struggling to garner **sympathy and leniency** from others.  
- They weaponize perceived **ignorance or lack of privilege** to avoid accountability.  
- Example: *“I didn’t know that was wrong, I’m just trying to get by in a system that doesn’t favor people like me.”*

### **2. Dodging Responsibility & Accountability**  
- By pretending they don’t understand social norms, workplace rules, or legal matters, they can **evade consequences** for their actions.  
- They might claim they were **“confused”** or **“misunderstood”** when caught doing something unethical.  
- Example: *"Oh, I didn’t realize that was against the rules—I thought that was just how things are done in my culture!"*

### **3. Manipulating Perceptions of Power**  
- Some narcissists **play dumb** to make others **underestimate them**, only to later reveal they were more aware and calculated than they let on.  
- They may **act submissive** or **helpless**, then suddenly become aggressive or controlling once they gain enough leverage.  
- Example: *"Oh, I don’t know how things work here,"* (later) *"I’ve been watching and now I know exactly how to take advantage of this system."*

### **4. Creating an Excuse for Poor Behavior**  
- They might justify **rudeness, dishonesty, or exploitation** by pretending they are just **“doing what they have to do”** to survive.  
- Example: *“Where I come from, this is normal! You can’t expect me to follow your rules.”*  

### **5. Using Cultural Barriers as a Shield**  
- Some narcissists **selectively** play up **language barriers** or **lack of education** to avoid confrontation.  
- They may pretend they don’t understand when criticized but **miraculously comprehend** when something benefits them.  
- Example: *“Sorry, my English isn’t good,”* (but suddenly fluent when negotiating a deal).  

### **6. Reverse Gaslighting (Acting Like Others Are Oppressing Them)**  
- They might accuse others of **xenophobia, discrimination, or elitism** when called out for **dishonest or manipulative** behavior.  
- This puts the other person in a **defensive position**, making them feel guilty for questioning the narcissist.  
- Example: *"You just don’t like me because I’m different!"* (When in reality, they were being called out for unethical behavior).  

### **7. Flipping the Narrative for Personal Gain**  
- They may use their **fake “underdog” status** to **gain access to opportunities, free assistance, or forgiveness.**  
- Example: *“I’m just trying to make a better life, why are you being so hard on me?”*  

---

### **Final Thoughts:**  
A **narcissist pretending to be an uneducated immigrant** is often **a manipulative strategy** rather than a genuine struggle. They use this act **as a tool** to dodge accountability, gain sympathy, and avoid consequences. It’s a **power move disguised as helplessness.**  

The key to handling this? **See through the act, set firm boundaries, and don’t fall for guilt-tripping tactics.**
```