### PR TITLE
Update 壞人裝好人.md

### DIFF
--- a/好人裝壞人/壞人裝好人.md
+++ b/好人裝壞人/壞人裝好人.md
@@ -1,1 +1,17 @@
+# 壞人裝好人
 
+When a narcissistic college friend loves to say **"Mistakes be made,"** they're likely using it as a way to dodge accountability, brush off responsibility, or even subtly manipulate others into accepting their actions without question. It’s a phrase that downplays errors as if they’re just part of the natural order, rather than something they personally caused or should take responsibility for.  
+
+### What They Might Mean:
+1. **Deflection** – "Yeah, mistakes happen, but don’t look at me."
+2. **Minimization** – "It’s not a big deal; stop making it one."
+3. **Gaslighting** – "If everyone makes mistakes, why are you focusing on mine?"
+4. **False Wisdom** – Trying to sound deep or profound while dodging blame.
+5. **Rewriting History** – Making their actions seem like an inevitable part of the process, rather than a failure of judgment.  
+
+### How to Handle It:
+- **Call it out directly** – “Yeah, but who made the mistake, though?”  
+- **Throw it back at them** – “If mistakes be made, who’s fixing them?”  
+- **Stay factual** – “Sure, but this particular mistake could have been avoided.”  
+
+At the end of the day, it’s just a self-serving phrase to keep their ego intact while avoiding consequences.


### PR DESCRIPTION
```markdown
# 壞人裝好人

When a narcissistic college friend loves to say **"Mistakes be made,"** they're likely using it as a way to dodge accountability, brush off responsibility, or even subtly manipulate others into accepting their actions without question. It’s a phrase that downplays errors as if they’re just part of the natural order, rather than something they personally caused or should take responsibility for.  

### What They Might Mean:
1. **Deflection** – "Yeah, mistakes happen, but don’t look at me."
2. **Minimization** – "It’s not a big deal; stop making it one."
3. **Gaslighting** – "If everyone makes mistakes, why are you focusing on mine?"
4. **False Wisdom** – Trying to sound deep or profound while dodging blame.
5. **Rewriting History** – Making their actions seem like an inevitable part of the process, rather than a failure of judgment.  

### How to Handle It:
- **Call it out directly** – “Yeah, but who made the mistake, though?”  
- **Throw it back at them** – “If mistakes be made, who’s fixing them?”  
- **Stay factual** – “Sure, but this particular mistake could have been avoided.”  

At the end of the day, it’s just a self-serving phrase to keep their ego intact while avoiding consequences.
```